### PR TITLE
Add optional Google Analytics via site-config and update templates/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ Static single-page academic website.
 python scripts/build_site.py
 ```
 
+## Google Analytics setup
+- Open `scripts/site-config.js`.
+- Set `googleAnalyticsMeasurementId` to your Google Analytics 4 Measurement ID (for example `G-XXXXXXXXXX`).
+- Rebuild the site after changing the ID:
+
+```bash
+python scripts/build_site.py
+```
+
+If the measurement ID is left blank, Google Analytics is not loaded.
+
 ## Run locally
 ```bash
 python -m http.server 8000

--- a/index.html
+++ b/index.html
@@ -71,7 +71,23 @@
   </main>
 
   <script src="scripts/render-markdown.js"></script>
+  <script src="scripts/site-config.js"></script>
   <script>
+    const gaMeasurementId = window.siteConfig?.googleAnalyticsMeasurementId?.trim();
+
+    if (gaMeasurementId) {
+      const gaScript = document.createElement("script");
+      gaScript.async = true;
+      gaScript.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(gaMeasurementId)}`;
+      document.head.appendChild(gaScript);
+
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      window.gtag = gtag;
+      gtag("js", new Date());
+      gtag("config", gaMeasurementId);
+    }
+
     document.getElementById("year").textContent = new Date().getFullYear();
     document.getElementById("updated").textContent = document.lastModified;
     window.loadMarkdownSections();

--- a/index.template.html
+++ b/index.template.html
@@ -11,80 +11,86 @@
 <body>
   <header class="site-header">
     <div class="wrap">
-   <div class="title-block">
-  <img class="profile-pic" src="assets/pic2024.jpg" alt="Antoine Germain" />
+      <div class="title-block">
+        <img class="profile-pic" src="assets/pic2024.jpg" alt="Antoine Germain" />
 
-  <div class="title-text">
-    <h1>Antoine Germain</h1>
+        <div class="title-text">
+          <h1>Antoine Germain</h1>
 
-    <!-- Make contact obvious -->
-    <p class="contact-line">
-      <a class="email" href="mailto:germain1@upenn.edu">germain1@upenn.edu</a>
-    </p>
+          <p class="contact-line">
+            <a class="email" href="mailto:germain1@upenn.edu">germain1@upenn.edu</a>
+          </p>
 
-    <!-- Big CV link first thing -->
-    <p class="cv-cta">
-      <a class="cv-button" href="assets/germain_CV.pdf">CV (PDF)</a>
-    </p>
+          <p class="cv-cta">
+            <a class="cv-button" href="assets/germain_CV.pdf">CV (PDF)</a>
+          </p>
 
-    <!-- Icon links -->
-    <nav class="icon-links" aria-label="Social links">
-      <a class="icon-link" href="https://x.com/ant1germain" aria-label="X (Twitter)" title="X">
-        <!-- X icon (simple) -->
-        <svg viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M18.9 2H22l-6.8 7.8L23 22h-6.8l-5.3-6.6L5 22H2l7.4-8.5L1 2h7l4.8 6.2L18.9 2zm-1.2 18h1.7L6.9 3.9H5.1L17.7 20z"/>
-        </svg>
-      </a>
+          <nav class="icon-links" aria-label="Social links">
+            <a class="icon-link icon-x" href="https://x.com/ant1germain" aria-label="X (Twitter)" title="X">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M18.9 2H22l-6.8 7.8L23 22h-6.8l-5.3-6.6L5 22H2l7.4-8.5L1 2h7l4.8 6.2L18.9 2zm-1.2 18h1.7L6.9 3.9H5.1L17.7 20z"/>
+              </svg>
+            </a>
 
-      <a class="icon-link" href="https://orcid.org/0000-0002-4701-9337" aria-label="ORCID" title="ORCID">
-        <!-- ORCID icon -->
-        <svg viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1.8 15.7H8.3V9.2h1.9v8.5zm-.95-9.7a1.1 1.1 0 1 1 0-2.2 1.1 1.1 0 0 1 0 2.2zM12.2 9.2h3.1c2.6 0 4.4 1.7 4.4 4.3 0 2.6-1.8 4.2-4.4 4.2h-3.1V9.2zm3 6.8c1.5 0 2.4-.9 2.4-2.5 0-1.6-.9-2.6-2.4-2.6h-1v5.1h1z"/>
-        </svg>
-      </a>
+            <a class="icon-link icon-orcid" href="https://orcid.org/0000-0002-4701-9337" aria-label="ORCID" title="ORCID">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1.8 15.7H8.3V9.2h1.9v8.5zm-.95-9.7a1.1 1.1 0 1 1 0-2.2 1.1 1.1 0 0 1 0 2.2zM12.2 9.2h3.1c2.6 0 4.4 1.7 4.4 4.3 0 2.6-1.8 4.2-4.4 4.2h-3.1V9.2zm3 6.8c1.5 0 2.4-.9 2.4-2.5 0-1.6-.9-2.6-2.4-2.6h-1v5.1h1z"/>
+              </svg>
+            </a>
 
-      <a class="icon-link" href="https://www.linkedin.com/in/antoinegermain-be/" aria-label="LinkedIn" title="LinkedIn">
-        <!-- LinkedIn icon -->
-        <svg viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M20.45 20.45h-3.55v-5.4c0-1.29-.02-2.95-1.8-2.95-1.8 0-2.08 1.4-2.08 2.85v5.5H9.5V9h3.4v1.56h.05c.47-.9 1.62-1.85 3.33-1.85 3.56 0 4.22 2.35 4.22 5.4v6.34zM5.34 7.43a2.06 2.06 0 1 1 0-4.12 2.06 2.06 0 0 1 0 4.12zM7.12 20.45H3.56V9h3.56v11.45z"/>
-        </svg>
-      </a>
-    </nav>
-  </div>
-</div>
-</div>
-</header>
+            <a class="icon-link icon-linkedin" href="https://www.linkedin.com/in/antoinegermain-be/" aria-label="LinkedIn" title="LinkedIn">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M20.45 20.45h-3.55v-5.4c0-1.29-.02-2.95-1.8-2.95-1.8 0-2.08 1.4-2.08 2.85v5.5H9.5V9h3.4v1.56h.05c.47-.9 1.62-1.85 3.33-1.85 3.56 0 4.22 2.35 4.22 5.4v6.34zM5.34 7.43a2.06 2.06 0 1 1 0-4.12 2.06 2.06 0 0 1 0 4.12zM7.12 20.45H3.56V9h3.56v11.45z"/>
+              </svg>
+            </a>
+          </nav>
+        </div>
+      </div>
+    </div>
+  </header>
 
   <main class="wrap">
-  <section id="about">
-  <p class="about-compact">
-    I am a postdoctoral fellow at the <a href="https://sp2.upenn.edu/">University of Pennsylvania School of Social Policy and Practice</a>.  I hold a PhD in Economics from <a href="https://uclouvain.be/en/research-institutes/lidam">CORE/LIDAM, UCLouvain</a>
-    obtained in June 2025 as part of thr  <a href="https://www.edpqe.eu/">European Doctoral Program</a>.
-  </p>
+    <section id="about">
+      <p class="about-compact">
+        I am a postdoctoral fellow at the <a href="https://sp2.upenn.edu/">University of Pennsylvania School of Social Policy and Practice</a>. I hold a PhD in Economics from <a href="https://uclouvain.be/en/research-institutes/lidam">CORE/LIDAM, UCLouvain</a>
+        obtained in June 2025 as part of <a href="https://www.edpqe.eu/">the European doctoral program</a>.
+      </p>
 
-  <p class="about-compact">
-    My research fields are public economics, labor economics and social choice theory. I evaluate public policies when agents have heterogeneous tastes and when labor markets are imperfect.
-  </p>
-</section>
+      <p class="about-compact">
+        My research fields are public economics, labor economics and social choice theory. I evaluate public policies when agents have heterogeneous tastes and when labor markets are imperfect.
+      </p>
+    </section>
 
-
-    {{PAPERS_HTML}}
-
-    {{TEACHING_HTML}}
-
-    {{POLICY_HTML}}
-
+    <section id="papers" class="markdown-section" data-md="content/papers.md"></section>
+    <section id="teaching" class="markdown-section" data-md="content/teaching.md"></section>
+    <section id="policy" class="markdown-section" data-md="content/policy.md"></section>
 
     <footer class="site-footer">
-      <p class="small">
-        © <span id="year"></span> Antoine Germain. Last updated: <span id="updated"></span>.
-      </p>
+      <p class="small">© <span id="year"></span> Antoine Germain. Last updated: <span id="updated"></span>.</p>
     </footer>
   </main>
 
+  <script src="scripts/render-markdown.js"></script>
+  <script src="scripts/site-config.js"></script>
   <script>
+    const gaMeasurementId = window.siteConfig?.googleAnalyticsMeasurementId?.trim();
+
+    if (gaMeasurementId) {
+      const gaScript = document.createElement("script");
+      gaScript.async = true;
+      gaScript.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(gaMeasurementId)}`;
+      document.head.appendChild(gaScript);
+
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      window.gtag = gtag;
+      gtag("js", new Date());
+      gtag("config", gaMeasurementId);
+    }
+
     document.getElementById("year").textContent = new Date().getFullYear();
     document.getElementById("updated").textContent = document.lastModified;
+    window.loadMarkdownSections();
   </script>
 </body>
 </html>

--- a/scripts/site-config.js
+++ b/scripts/site-config.js
@@ -1,0 +1,4 @@
+window.siteConfig = {
+  // Google Analytics 4 Measurement ID for this site.
+  googleAnalyticsMeasurementId: "G-BC43SFNGM8"
+};


### PR DESCRIPTION
### Motivation
- Provide an easy, opt-in way to enable Google Analytics 4 for the static site via a single configuration file. 
- Keep the main templates and content rendering Markdown-first while adding GA without hard-coding the ID into templates.
- Improve template HTML formatting and icon class names for clearer styling hooks.

### Description
- Add a new `scripts/site-config.js` exposing `window.siteConfig` with `googleAnalyticsMeasurementId` for GA setup. 
- Update `index.html` and `index.template.html` to load `scripts/site-config.js` and conditionally inject the GA loader and initialize `gtag` when `googleAnalyticsMeasurementId` is set. 
- Replace template placeholders with the Markdown-driven sections (`<section id="papers" ...>`, `<section id="teaching" ...>`, `<section id="policy" ...>`) and ensure `window.loadMarkdownSections()` is called. 
- Document the new GA setup in `README.md` with instructions to edit `scripts/site-config.js` and rebuild using `python scripts/build_site.py`, and tidy markup/class names for social icons.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c0125bdaec8333b7d306f63fcd6f8e)