### PR TITLE
CSS: justify abstract paragraphs and adjust font-size

### DIFF
--- a/style.css
+++ b/style.css
@@ -120,7 +120,11 @@ details.abstract > summary {
 }
 details.abstract > summary::-webkit-details-marker { display: none; }
 details.abstract > summary:hover { text-decoration: underline; }
-details.abstract p { margin: .45rem 0; }
+details.abstract p {
+  margin: .45rem 0;
+  text-align: justify;
+  font-size: .95em;
+}
 
 .site-footer {
   margin-top: 2rem;
@@ -146,4 +150,3 @@ details.abstract p { margin: .45rem 0; }
   .paper-heading { display: block; }
   .paper-inline-links { display: inline; margin-left: .35rem; }
 }
-


### PR DESCRIPTION
### Motivation
- Improve readability and visual density of the abstract by aligning paragraph text and slightly reducing its font size.

### Description
- Modify `details.abstract p` in `style.css` to add `text-align: justify;` and `font-size: .95em;` while keeping the existing margin.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee32eb1acc8333ac503a9b9b983b81)